### PR TITLE
Add theme support and UI refactor

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,50 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --color-bg: #f3f4f6;
+  --color-text: #1f2937;
+  --color-text-secondary: #4b5563;
+  --color-surface: #ffffff;
+  --color-panel-border: #e5e7eb;
+  --color-primary: #3b82f6;
+  --color-success: #22c55e;
+  --color-danger: #dc2626;
+  --color-warning: #f59e0b;
+  --board-bg: #1f2937;
+  --board-border: #9ca3af;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+[data-theme='dark'] {
+  --color-bg: #111827;
+  --color-text: #f3f4f6;
+  --color-text-secondary: #9ca3af;
+  --color-surface: #1f2937;
+  --color-panel-border: #374151;
+  --color-primary: #3b82f6;
+  --color-success: #22c55e;
+  --color-danger: #f87171;
+  --color-warning: #facc15;
+  --board-bg: #000000;
+  --board-border: #4b5563;
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+.panel {
+  @apply rounded-lg shadow-md p-4;
+  background: var(--color-surface);
+  border: 1px solid var(--color-panel-border);
+}
+
+.panel-title {
+  @apply text-lg font-bold mb-3 text-center;
+  color: var(--color-text);
+}
+
+.text-secondary {
+  color: var(--color-text-secondary);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" data-theme="light">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Panel from '@/components/ui/Panel';
 
 const Controls: React.FC = () => {
   const controls = [
@@ -15,22 +16,20 @@ const Controls: React.FC = () => {
     { key: 'R', action: 'Restart (when game over)' },
   ];
 
-  return (
-    <div className="bg-white p-4 rounded-lg shadow-md">
-      <h2 className="text-lg font-bold mb-3 text-center">Controls</h2>
-      
-      <div className="space-y-2">
-        {controls.map(({ key, action }, index) => (
-          <div key={index} className="flex justify-between items-center text-sm">
-            <span className="font-mono bg-gray-100 px-2 py-1 rounded border">
-              {key}
-            </span>
-            <span className="text-gray-700">{action}</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+    return (
+      <Panel title="Controls">
+        <div className="space-y-2">
+          {controls.map(({ key, action }, index) => (
+            <div key={index} className="flex justify-between items-center text-sm">
+              <span className="font-mono bg-[var(--color-bg)] px-2 py-1 rounded border border-[var(--color-panel-border)]">
+                {key}
+              </span>
+              <span className="text-secondary">{action}</span>
+            </div>
+          ))}
+        </div>
+      </Panel>
+    );
 };
 
 export default Controls;

--- a/src/components/GameInfo.tsx
+++ b/src/components/GameInfo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Panel from '@/components/ui/Panel';
 
 interface GameInfoProps {
   score: number;
@@ -17,45 +18,43 @@ const GameInfo: React.FC<GameInfoProps> = ({
   gameOver, 
   paused 
 }) => {
-  return (
-    <div className="bg-white p-4 rounded-lg shadow-md">
-      <h2 className="text-lg font-bold mb-3 text-center">Game Info</h2>
-      
-      <div className="space-y-3">
-        <div className="flex justify-between items-center">
-          <span className="font-semibold text-gray-700">Score:</span>
-          <span className="font-mono text-lg">{score.toLocaleString()}</span>
-        </div>
-        
-        <div className="flex justify-between items-center">
-          <span className="font-semibold text-gray-700">Level:</span>
-          <span className="font-mono text-lg">{level}</span>
-        </div>
-        
-        <div className="flex justify-between items-center">
-          <span className="font-semibold text-gray-700">Lines:</span>
-          <span className="font-mono text-lg">{lines}</span>
-        </div>
-
-        {(gameOver || paused) && (
-          <div className="mt-4 pt-3 border-t border-gray-200">
-            {gameOver && (
-              <div className="text-center">
-                <p className="text-red-600 font-bold text-lg mb-2">Game Over!</p>
-                <p className="text-sm text-gray-600">Press R to restart</p>
-              </div>
-            )}
-            {paused && !gameOver && (
-              <div className="text-center">
-                <p className="text-yellow-600 font-bold text-lg mb-2">Paused</p>
-                <p className="text-sm text-gray-600">Press P to resume</p>
-              </div>
-            )}
+    return (
+      <Panel title="Game Info">
+        <div className="space-y-3">
+          <div className="flex justify-between items-center">
+            <span className="font-semibold text-secondary">Score:</span>
+            <span className="font-mono text-lg">{score.toLocaleString()}</span>
           </div>
-        )}
-      </div>
-    </div>
-  );
+
+          <div className="flex justify-between items-center">
+            <span className="font-semibold text-secondary">Level:</span>
+            <span className="font-mono text-lg">{level}</span>
+          </div>
+
+          <div className="flex justify-between items-center">
+            <span className="font-semibold text-secondary">Lines:</span>
+            <span className="font-mono text-lg">{lines}</span>
+          </div>
+
+          {(gameOver || paused) && (
+            <div className="mt-4 pt-3 border-t border-[var(--color-panel-border)]">
+              {gameOver && (
+                <div className="text-center">
+                  <p className="text-[var(--color-danger)] font-bold text-lg mb-2">Game Over!</p>
+                  <p className="text-sm text-secondary">Press R to restart</p>
+                </div>
+              )}
+              {paused && !gameOver && (
+                <div className="text-center">
+                  <p className="text-[var(--color-warning)] font-bold text-lg mb-2">Paused</p>
+                  <p className="text-sm text-secondary">Press P to resume</p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </Panel>
+    );
 };
 
 export default GameInfo;

--- a/src/components/TetrisBlock.tsx
+++ b/src/components/TetrisBlock.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { TetrominoType } from '@/types/tetris';
+import { TETROMINO_COLORS } from '@/utils/tetrominos';
+
+interface TetrisBlockProps {
+  type: TetrominoType | null;
+  ghost?: boolean;
+}
+
+const TetrisBlock: React.FC<TetrisBlockProps> = ({ type, ghost }) => {
+  const getBlockStyle = () => {
+    if (!type) {
+      return 'bg-[var(--board-bg)] border border-[var(--board-border)]';
+    }
+
+    const baseStyle = 'border border-[var(--board-border)]';
+
+    if (ghost) {
+      return `${baseStyle} border-2 border-dashed opacity-30`;
+    }
+
+    return `${baseStyle} shadow-sm`;
+  };
+
+  const getBlockColor = () => {
+    if (!type) return '';
+    return TETROMINO_COLORS[type];
+  };
+
+  return (
+    <div
+      className={`w-6 h-6 ${getBlockStyle()}`}
+      style={{
+        backgroundColor: type ? getBlockColor() : undefined
+      }}
+    />
+  );
+};
+
+export default TetrisBlock;

--- a/src/components/TetrisBoard.tsx
+++ b/src/components/TetrisBoard.tsx
@@ -2,42 +2,7 @@
 
 import React from 'react';
 import { TetrominoType, Tetromino } from '@/types/tetris';
-import { TETROMINO_COLORS } from '@/utils/tetrominos';
-
-interface TetrisBlockProps {
-  type: TetrominoType | null;
-  ghost?: boolean;
-}
-
-const TetrisBlock: React.FC<TetrisBlockProps> = ({ type, ghost }) => {
-  const getBlockStyle = () => {
-    if (!type) {
-      return 'bg-gray-900 border border-gray-700';
-    }
-
-    const baseStyle = 'border border-gray-400';
-    
-    if (ghost) {
-      return `${baseStyle} border-2 border-dashed opacity-30`;
-    }
-
-    return `${baseStyle} shadow-sm`;
-  };
-
-  const getBlockColor = () => {
-    if (!type) return '';
-    return TETROMINO_COLORS[type];
-  };
-
-  return (
-    <div 
-      className={`w-6 h-6 ${getBlockStyle()}`}
-      style={{
-        backgroundColor: type ? getBlockColor() : undefined
-      }}
-    />
-  );
-};
+import TetrisBlock from '@/components/TetrisBlock';
 
 interface TetrisBoardProps {
   board: (TetrominoType | null)[][];
@@ -127,9 +92,9 @@ const TetrisBoard: React.FC<TetrisBoardProps> = ({
     }
   }
 
-  return (
-    <div className="inline-block border-2 border-gray-300 bg-black p-1">
-      <div className="grid grid-cols-10 gap-0">
+    return (
+      <div className="inline-block border-2 border-[var(--board-border)] bg-[var(--board-bg)] p-1">
+        <div className="grid grid-cols-10 gap-0">
         {renderBoard.map((row, y) =>
           row.map((cell, x) => {
             const isGhost = ghostPiece && 

--- a/src/components/TetrisGame.tsx
+++ b/src/components/TetrisGame.tsx
@@ -6,16 +6,18 @@ import { NextPieces, HoldPiece } from '@/components/TetrominoPreview';
 import GameInfo from '@/components/GameInfo';
 import Controls from '@/components/Controls';
 import { useGameLogic } from '@/hooks/useGameLogic';
+import ThemeToggle from '@/components/ui/ThemeToggle';
 
 const TetrisGame: React.FC = () => {
   const { gameState, resetGame, togglePause } = useGameLogic();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100 to-purple-100 p-4">
-      <div className="max-w-6xl mx-auto">
-        <h1 className="text-4xl font-bold text-center mb-8 text-gray-800">
-          Tetris
-        </h1>
+      <div className="min-h-screen p-4">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex justify-between items-center mb-8">
+            <h1 className="text-4xl font-bold text-center">Tetris</h1>
+            <ThemeToggle />
+          </div>
         
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
           {/* Left panel - Hold and Controls */}
@@ -42,14 +44,16 @@ const TetrisGame: React.FC = () => {
               <button
                 onClick={togglePause}
                 disabled={gameState.gameOver}
-                className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 rounded text-white disabled:opacity-50 disabled:cursor-not-allowed hover:brightness-110"
+                style={{ backgroundColor: 'var(--color-primary)' }}
               >
                 {gameState.paused ? 'Resume' : 'Pause'}
               </button>
-              
+
               <button
                 onClick={resetGame}
-                className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
+                className="px-4 py-2 rounded text-white hover:brightness-110"
+                style={{ backgroundColor: 'var(--color-success)' }}
               >
                 New Game
               </button>
@@ -70,12 +74,12 @@ const TetrisGame: React.FC = () => {
         </div>
         
         {/* Instructions */}
-        <div className="mt-8 text-center text-gray-600 text-sm">
-          <p>Use keyboard controls to play. Focus on the game area and use the keys shown in the Controls panel.</p>
+          <div className="mt-8 text-center text-secondary text-sm">
+            <p>Use keyboard controls to play. Focus on the game area and use the keys shown in the Controls panel.</p>
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
 };
 
 export default TetrisGame;

--- a/src/components/TetrominoPreview.tsx
+++ b/src/components/TetrominoPreview.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { TetrominoType } from '@/types/tetris';
 import { TETROMINO_SHAPES, TETROMINO_COLORS } from '@/utils/tetrominos';
+import Panel from '@/components/ui/Panel';
 
 interface TetrominoPreviewProps {
   type: TetrominoType | null;
@@ -20,11 +21,11 @@ const TetrominoPreview: React.FC<TetrominoPreviewProps> = ({
 
   const renderPreview = () => {
     if (!type) {
-      return (
-        <div className={`${containerSize} border border-gray-300 bg-gray-100 flex items-center justify-center`}>
-          <span className="text-gray-400 text-xs">Empty</span>
-        </div>
-      );
+        return (
+          <div className={`${containerSize} border border-[var(--color-panel-border)] bg-[var(--color-bg)] flex items-center justify-center`}>
+            <span className="text-secondary text-xs">Empty</span>
+          </div>
+        );
     }
 
     const shape = TETROMINO_SHAPES[type][0];
@@ -47,7 +48,7 @@ const TetrominoPreview: React.FC<TetrominoPreviewProps> = ({
     const height = maxY - minY + 1;
 
     return (
-      <div className={`${containerSize} border border-gray-300 bg-gray-900 flex items-center justify-center p-1`}>
+        <div className={`${containerSize} border border-[var(--board-border)] bg-[var(--board-bg)] flex items-center justify-center p-1`}>
         <div 
           className="grid gap-0"
           style={{ 
@@ -64,7 +65,7 @@ const TetrominoPreview: React.FC<TetrominoPreviewProps> = ({
               return (
                 <div
                   key={`${x}-${y}`}
-                  className={`${blockSize} ${hasBlock ? 'border border-gray-400' : ''}`}
+                    className={`${blockSize} ${hasBlock ? 'border border-[var(--board-border)]' : ''}`}
                   style={{
                     backgroundColor: hasBlock ? color : 'transparent'
                   }}
@@ -78,8 +79,8 @@ const TetrominoPreview: React.FC<TetrominoPreviewProps> = ({
   };
 
   return (
-    <div className="flex flex-col items-center mb-2">
-      <h3 className="text-sm font-semibold mb-1 text-gray-700">{title}</h3>
+      <div className="flex flex-col items-center mb-2">
+        <h3 className="text-sm font-semibold mb-1 text-secondary">{title}</h3>
       {renderPreview()}
     </div>
   );
@@ -89,42 +90,40 @@ interface NextPiecesProps {
   nextPieces: TetrominoType[];
 }
 
-export const NextPieces: React.FC<NextPiecesProps> = ({ nextPieces }) => {
-  return (
-    <div className="bg-white p-4 rounded-lg shadow-md">
-      <h2 className="text-lg font-bold mb-3 text-center">Next</h2>
-      <div className="space-y-2">
-        {nextPieces.map((piece, index) => (
-          <TetrominoPreview
-            key={index}
-            type={piece}
-            title={`${index + 1}`}
-            small={index > 0}
-          />
-        ))}
-      </div>
-    </div>
-  );
-};
+  export const NextPieces: React.FC<NextPiecesProps> = ({ nextPieces }) => {
+    return (
+      <Panel title="Next">
+        <div className="space-y-2">
+          {nextPieces.map((piece, index) => (
+            <TetrominoPreview
+              key={index}
+              type={piece}
+              title={`${index + 1}`}
+              small={index > 0}
+            />
+          ))}
+        </div>
+      </Panel>
+    );
+  };
 
 interface HoldPieceProps {
   holdPiece: TetrominoType | null;
   canHold: boolean;
 }
 
-export const HoldPiece: React.FC<HoldPieceProps> = ({ holdPiece, canHold }) => {
-  return (
-    <div className={`bg-white p-4 rounded-lg shadow-md ${!canHold ? 'opacity-50' : ''}`}>
-      <h2 className="text-lg font-bold mb-3 text-center">Hold</h2>
-      <TetrominoPreview
-        type={holdPiece}
-        title=""
-      />
-      {!canHold && (
-        <p className="text-xs text-gray-500 text-center mt-2">
-          Used
-        </p>
-      )}
-    </div>
-  );
-};
+  export const HoldPiece: React.FC<HoldPieceProps> = ({ holdPiece, canHold }) => {
+    return (
+      <Panel title="Hold" className={!canHold ? 'opacity-50' : ''}>
+        <TetrominoPreview
+          type={holdPiece}
+          title=""
+        />
+        {!canHold && (
+          <p className="text-xs text-secondary text-center mt-2">
+            Used
+          </p>
+        )}
+      </Panel>
+    );
+  };

--- a/src/components/ui/Panel.tsx
+++ b/src/components/ui/Panel.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from 'react';
+
+interface PanelProps {
+  title?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+const Panel: React.FC<PanelProps> = ({ title, children, className = '' }) => (
+  <div className={`panel ${className}`.trim()}>
+    {title && <h2 className="panel-title">{title}</h2>}
+    {children}
+  </div>
+);
+
+export default Panel;

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const ThemeToggle: React.FC = () => {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+      className="px-2 py-1 text-sm border rounded"
+    >
+      {theme === 'light' ? 'Dark mode' : 'Light mode'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/hooks/useGameLogic.ts
+++ b/src/hooks/useGameLogic.ts
@@ -1,11 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { 
-  GameState, 
-  Tetromino, 
-  Position, 
-  TetrominoType 
+import {
+  GameState,
+  Tetromino,
+  TetrominoType
 } from '@/types/tetris';
 import {
   createInitialGameState,
@@ -23,10 +22,9 @@ import {
 } from '@/utils/tetrominos';
 
 export function useGameLogic() {
-  const [gameState, setGameState] = useState<GameState>(() => createInitialGameState());
-  const [lastDropTime, setLastDropTime] = useState(Date.now());
-  const dropTimeRef = useRef(lastDropTime);
-  const gameLoopRef = useRef<number | null>(null);
+    const [gameState, setGameState] = useState<GameState>(() => createInitialGameState());
+    const dropTimeRef = useRef(Date.now());
+    const gameLoopRef = useRef<number | null>(null);
 
   const movePiece = useCallback((dx: number, dy: number) => {
     setGameState(prevState => {
@@ -205,10 +203,10 @@ export function useGameLogic() {
     });
   }, []);
 
-  const resetGame = useCallback(() => {
-    setGameState(createInitialGameState());
-    setLastDropTime(Date.now());
-  }, []);
+    const resetGame = useCallback(() => {
+      setGameState(createInitialGameState());
+      dropTimeRef.current = Date.now();
+    }, []);
 
   const togglePause = useCallback(() => {
     setGameState(prevState => ({


### PR DESCRIPTION
## Summary
- add CSS variables and reusable Panel for consistent theming
- provide light/dark ThemeToggle and refactor components to use it
- clean up game logic and extract TetrisBlock component

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68958c3c3b308327914157065d5ae44b