### PR TITLE
Fix hydration mismatch in theme provider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html
+      lang="en"
+      data-theme="light"
+      style={{ colorScheme: "light" }}
+      suppressHydrationWarning
+    >
       <body className="antialiased">
         <ThemeProvider attribute="data-theme" defaultTheme="light">
           {children}


### PR DESCRIPTION
## Summary
- ensure server markup matches client when using next-themes by adding default theme attributes and suppressing hydration warnings on root html element

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895b790e790832781d109193a795011