### PR TITLE
Ensure seven-bag generator consumes one piece per spawn

### DIFF
--- a/src/hooks/usePieceQueue.ts
+++ b/src/hooks/usePieceQueue.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useReducer, useEffect, useCallback } from 'react';
+import { useReducer, useEffect, useCallback, useRef } from 'react';
 import { sevenBag } from '@/organisms/sevenBag';
 import { TetrominoType } from '@/types/tetris';
 
@@ -10,7 +10,6 @@ type State = {
 };
 
 type Action =
-  | { type: 'INIT'; preview: number }
   | { type: 'CONSUME_ONE'; preview: number; piece: TetrominoType }
   | { type: 'HARD_RESET'; preview: number };
 
@@ -20,14 +19,15 @@ function fillQueue(q: TetrominoType[], need: number): TetrominoType[] {
   return out;
 }
 
+function init(preview: number): State {
+  const current = sevenBag.next();
+  const queue = fillQueue([], preview);
+  return { current, queue };
+}
+
 function reducer(state: State, action: Action): State {
   const preview = action.preview;
   switch (action.type) {
-    case 'INIT': {
-      const current = sevenBag.next();
-      const queue = fillQueue([], preview);
-      return { current, queue };
-    }
     case 'CONSUME_ONE': {
       const nextCurrent = action.piece;
       const rest = state.queue.slice(1);
@@ -35,9 +35,7 @@ function reducer(state: State, action: Action): State {
       return { current: nextCurrent, queue };
     }
     case 'HARD_RESET': {
-      const current = sevenBag.next();
-      const queue = fillQueue([], preview);
-      return { current, queue };
+      return init(preview);
     }
     default:
       return state;
@@ -45,13 +43,15 @@ function reducer(state: State, action: Action): State {
 }
 
 export function usePieceQueue(preview = 5) {
-  const [state, dispatch] = useReducer(reducer, {
-    current: 'I' as TetrominoType,
-    queue: [] as TetrominoType[],
-  });
+  const [state, dispatch] = useReducer(reducer, preview, init);
+  const initialized = useRef(false);
 
   useEffect(() => {
-    dispatch({ type: 'INIT', preview });
+    if (initialized.current) {
+      dispatch({ type: 'HARD_RESET', preview });
+    } else {
+      initialized.current = true;
+    }
   }, [preview]);
 
   const spawnNext = useCallback((): TetrominoType => {


### PR DESCRIPTION
## Summary
- prevent duplicate `sevenBag.next()` calls when queue is empty
- pass generated piece through reducer to keep seven-bag order

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895b93a603c8327ad33601cb14e097f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic for handling piece consumption, ensuring more explicit and predictable behavior when advancing to the next piece in the queue. No changes to visible gameplay or user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->